### PR TITLE
Use typed function, instead of casting

### DIFF
--- a/lib/providers/notes.dart
+++ b/lib/providers/notes.dart
@@ -16,8 +16,7 @@ class Notes with ChangeNotifier {
   }
 
   Future<List<Note>> getNotesFromDB() async {
-    List<dynamic> notes = await notesDB.getAll();
-    List<Note> tempNotes = notes.map((e) => e as Note).toList();
+    List<Note> notes = await notesDB.getAllType<Note>();
     return tempNotes;
   }
 


### PR DESCRIPTION
This will only pull the Note type from the SimpleDatabase, as currently you are pulling all types as dynamic and then casting to Note, this is safer and faster